### PR TITLE
Align mini program API with latest client changes

### DIFF
--- a/Controllers/MiniProgramApiController.cs
+++ b/Controllers/MiniProgramApiController.cs
@@ -1,6 +1,7 @@
-﻿using StudentInformationSystem.Models;
+using StudentInformationSystem.Helpers;
+using StudentInformationSystem.Models;
 using System;
-using System.Collections.Generic;
+using System.Data.Entity;
 using System.Linq;
 using System.Net;
 using System.Web.Http;
@@ -23,11 +24,14 @@ namespace StudentInformationSystem.Controllers
 
             if (user == null)
             {
-                return Unauthorized();
+                return Content(HttpStatusCode.Unauthorized, ApiResponse<object>.Fail("用户名或密码错误"));
             }
 
             // --- 新增的逻辑：根据角色查询真实姓名 ---
             string realName = user.Username; // 默认使用用户名
+            int? classId = null;
+            string className = null;
+            int? teacherId = null;
 
             if (user.Role == 2) // 如果是学生
             {
@@ -35,6 +39,8 @@ namespace StudentInformationSystem.Controllers
                 if (student != null)
                 {
                     realName = student.StudentName;
+                    classId = student.ClassID;
+                    className = student.Classes?.ClassName;
                 }
             }
             else if (user.Role == 1) // 如果是教师
@@ -43,6 +49,7 @@ namespace StudentInformationSystem.Controllers
                 if (teacher != null)
                 {
                     realName = teacher.TeacherName;
+                    teacherId = teacher.TeacherID;
                 }
             }
             // --- 逻辑结束 ---
@@ -51,13 +58,16 @@ namespace StudentInformationSystem.Controllers
             // 返回一个包含了真实姓名的新对象
             var userViewModel = new
             {
-                user.UserID,
+                UserId = user.UserID,
                 user.Username,
                 user.Role,
-                RealName = realName // 新增 RealName 字段
+                RealName = realName, // 新增 RealName 字段
+                ClassId = classId,
+                ClassName = className,
+                TeacherId = teacherId
             };
 
-            return Ok(userViewModel);
+            return Ok(ApiResponse<object>.Ok(userViewModel, "登录成功"));
         }
 
         // GET: api/MiniProgramApi/timetable?userId=...
@@ -68,13 +78,13 @@ namespace StudentInformationSystem.Controllers
             var user = db.Users.Find(userId);
             if (user == null)
             {
-                return NotFound();
+                return Content(HttpStatusCode.NotFound, ApiResponse<object>.Fail("未找到用户"));
             }
 
             if (user.Role == 2) // 学生
             {
                 var student = db.Students.FirstOrDefault(s => s.UserID == userId);
-                if (student == null) return NotFound();
+                if (student == null) return Content(HttpStatusCode.NotFound, ApiResponse<object>.Fail("未找到学生信息"));
 
                 var enrolledCourseIds = db.StudentCourses
                                           .Where(sc => sc.StudentID == student.StudentID)
@@ -83,6 +93,7 @@ namespace StudentInformationSystem.Controllers
                 var classSessions = db.ClassSessions.Include("Courses.Teachers")
                                       .Where(cs => enrolledCourseIds.Contains(cs.CourseID))
                                       .Select(cs => new {
+                                          cs.CourseID,
                                           cs.Courses.CourseName,
                                           cs.DayOfWeek,
                                           cs.StartPeriod,
@@ -93,12 +104,12 @@ namespace StudentInformationSystem.Controllers
                                           TeacherName = cs.Courses.Teachers.TeacherName
                                       })
                                       .ToList();
-                return Ok(classSessions);
+                return Ok(ApiResponse<object>.Ok(classSessions));
             }
             else if (user.Role == 1) // 教师
             {
                 var teacher = db.Teachers.FirstOrDefault(t => t.UserID == userId);
-                if (teacher == null) return NotFound();
+                if (teacher == null) return Content(HttpStatusCode.NotFound, ApiResponse<object>.Fail("未找到教师信息"));
 
                 var taughtCourseIds = db.Courses.Where(c => c.TeacherID == teacher.TeacherID)
                                         .Select(c => c.CourseID).ToList();
@@ -106,6 +117,7 @@ namespace StudentInformationSystem.Controllers
                 var classSessions = db.ClassSessions.Include("Courses")
                                       .Where(cs => taughtCourseIds.Contains(cs.CourseID))
                                       .Select(cs => new {
+                                          cs.CourseID,
                                           cs.Courses.CourseName,
                                           cs.DayOfWeek,
                                           cs.StartPeriod,
@@ -115,10 +127,10 @@ namespace StudentInformationSystem.Controllers
                                           cs.EndWeek
                                       })
                                       .ToList();
-                return Ok(classSessions);
+                return Ok(ApiResponse<object>.Ok(classSessions));
             }
 
-            return Ok(new object[0]);
+            return Ok(ApiResponse<object>.Ok(new object[0]));
         }
 
         // GET: api/miniprogram/grades?userId=...
@@ -130,17 +142,18 @@ namespace StudentInformationSystem.Controllers
             var user = db.Users.Find(userId);
             if (user == null || user.Role != 2) // 2 代表学生
             {
-                return BadRequest("当前用户不是学生");
+                return Content(HttpStatusCode.BadRequest, ApiResponse<object>.Fail("当前用户不是学生"));
             }
 
             var student = db.Students.FirstOrDefault(s => s.UserID == userId);
-            if (student == null) return NotFound();
+            if (student == null) return Content(HttpStatusCode.NotFound, ApiResponse<object>.Fail("未找到学生信息"));
 
             // 查询该学生的选课记录及成绩
             var grades = db.StudentCourses.Include("Courses")
                            .Where(sc => sc.StudentID == student.StudentID)
                            .Select(sc => new
                            {
+                               sc.CourseID,
                                CourseName = sc.Courses.CourseName,
                                Credits = sc.Courses.Credits,
                                // 如果 Grade 是 null，返回 "暂无"，否则返回具体分数
@@ -148,7 +161,7 @@ namespace StudentInformationSystem.Controllers
                            })
                            .ToList();
 
-            return Ok(grades);
+            return Ok(ApiResponse<object>.Ok(grades));
         }
 
         // GET: api/miniprogram/mycourses?userId=...
@@ -160,24 +173,25 @@ namespace StudentInformationSystem.Controllers
             var user = db.Users.Find(userId);
             if (user == null || user.Role != 1) // 1 代表教师
             {
-                return BadRequest("当前用户不是教师");
+                return Content(HttpStatusCode.BadRequest, ApiResponse<object>.Fail("当前用户不是教师"));
             }
 
             var teacher = db.Teachers.FirstOrDefault(t => t.UserID == userId);
-            if (teacher == null) return NotFound();
+            if (teacher == null) return Content(HttpStatusCode.NotFound, ApiResponse<object>.Fail("未找到教师信息"));
 
             // 查询该教师教授的课程
             var courses = db.Courses
                             .Where(c => c.TeacherID == teacher.TeacherID)
                             .Select(c => new
                             {
+                                c.CourseID,
                                 c.CourseName,
                                 c.Credits,
                                 Type = c.CourseType
                             })
                             .ToList();
 
-            return Ok(courses);
+            return Ok(ApiResponse<object>.Ok(courses));
         }
 
         // GET: api/miniprogram/stats?userId=...
@@ -190,7 +204,7 @@ namespace StudentInformationSystem.Controllers
             // 0 代表管理员 (根据之前的逻辑：1=教师, 2=学生)
             if (user == null || user.Role != 0)
             {
-                return BadRequest("当前用户不是管理员");
+                return Content(HttpStatusCode.BadRequest, ApiResponse<object>.Fail("当前用户不是管理员"));
             }
 
             // 统计各个表的数据量
@@ -204,7 +218,65 @@ namespace StudentInformationSystem.Controllers
                 UserCount = db.Users.Count()
             };
 
-            return Ok(stats);
+            return Ok(ApiResponse<object>.Ok(stats));
+        }
+
+        /// <summary>
+        /// 获取考试安排，支持学生、教师和管理员角色。
+        /// </summary>
+        /// <param name="userId">当前用户 ID。</param>
+        [HttpGet]
+        [Route("exams")]
+        public IHttpActionResult GetExams(int userId)
+        {
+            var user = db.Users.Find(userId);
+            if (user == null)
+            {
+                return Content(HttpStatusCode.NotFound, ApiResponse<object>.Fail("未找到用户"));
+            }
+
+            IQueryable<Exams> examsQuery = db.Exams.Include("Courses");
+
+            if (user.Role == 2) // 学生
+            {
+                var student = db.Students.FirstOrDefault(s => s.UserID == userId);
+                if (student == null)
+                {
+                    return Content(HttpStatusCode.NotFound, ApiResponse<object>.Fail("未找到学生信息"));
+                }
+
+                var enrolledCourseIds = db.StudentCourses
+                                          .Where(sc => sc.StudentID == student.StudentID)
+                                          .Select(sc => sc.CourseID);
+                examsQuery = examsQuery.Where(e => enrolledCourseIds.Contains(e.CourseID));
+            }
+            else if (user.Role == 1) // 教师
+            {
+                var teacher = db.Teachers.FirstOrDefault(t => t.UserID == userId);
+                if (teacher == null)
+                {
+                    return Content(HttpStatusCode.NotFound, ApiResponse<object>.Fail("未找到教师信息"));
+                }
+
+                var taughtCourseIds = db.Courses
+                                        .Where(c => c.TeacherID == teacher.TeacherID)
+                                        .Select(c => c.CourseID);
+                examsQuery = examsQuery.Where(e => taughtCourseIds.Contains(e.CourseID));
+            }
+
+            var exams = examsQuery
+                .Select(e => new
+                {
+                    e.ExamID,
+                    e.CourseID,
+                    e.ExamDate,
+                    e.ExamTime,
+                    e.Classroom,
+                    CourseName = e.Courses.CourseName
+                })
+                .ToList();
+
+            return Ok(ApiResponse<object>.Ok(exams));
         }
 
         // 注意：Dispose方法对于释放数据库连接很重要，请确保它存在

--- a/Helpers/ApiResponse.cs
+++ b/Helpers/ApiResponse.cs
@@ -1,0 +1,37 @@
+using System;
+
+namespace StudentInformationSystem.Helpers
+{
+    /// <summary>
+    /// 标准化的 API 响应包装，用于向小程序返回统一格式的数据。
+    /// </summary>
+    /// <typeparam name="T">返回数据类型。</typeparam>
+    public class ApiResponse<T>
+    {
+        public bool Success { get; set; }
+
+        public string Message { get; set; }
+
+        public T Data { get; set; }
+
+        public static ApiResponse<T> Ok(T data, string message = "")
+        {
+            return new ApiResponse<T>
+            {
+                Success = true,
+                Message = message,
+                Data = data
+            };
+        }
+
+        public static ApiResponse<T> Fail(string message)
+        {
+            return new ApiResponse<T>
+            {
+                Success = false,
+                Message = message,
+                Data = default
+            };
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -75,15 +75,18 @@
 
 ### 核心功能接口
 * **用户鉴权 (Auth)**
-    * `POST /api/miniprogram/login`: 用户登录，返回包含真实姓名 (RealName) 和角色 (Role) 的用户信息。
+    * `POST /api/miniprogram/login`: 用户登录，返回包含真实姓名 (RealName)、角色 (Role) 以及班级/教师标识的用户信息。
 * **课表查询 (Timetable)**
     * `GET /api/miniprogram/timetable`: 根据用户 ID 获取个性化课表（支持学生和教师视角）。
 * **学生端功能 (Student Features)**
     * `GET /api/miniprogram/grades`: 查询学生的选课及成绩信息。
+    * `GET /api/miniprogram/exams`: 获取学生关联课程的考试安排。
 * **教师端功能 (Teacher Features)**
     * `GET /api/miniprogram/mycourses`: 查询教师教授的课程列表及学分信息。
+    * `GET /api/miniprogram/exams`: 获取教师所授课程的考试安排。
 * **管理员功能 (Admin Features)**
     * `GET /api/miniprogram/stats`: 获取系统运行状态统计（包括用户、学生、教师、课程、班级总数）。
+    * `GET /api/miniprogram/exams`: 获取系统内所有课程的考试安排。
 
 ### 现实场景支持
 


### PR DESCRIPTION
## Summary
- standardize mini program API responses with a shared ApiResponse wrapper and richer login payload
- extend timetable/grades/course endpoints with identifiers and add a unified exams endpoint
- document the expanded mini program API surface in the README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69365f6df2b88320adcdd07e97414a56)